### PR TITLE
Refactor: Move Category Filter Into NavBar

### DIFF
--- a/src/components/collectibles/CategoryFilter.jsx
+++ b/src/components/collectibles/CategoryFilter.jsx
@@ -1,8 +1,3 @@
-import { useEffect, useState } from "react"
-import { getAllCategories } from "../managers/CategoriesManager"
-import { getAllCollectiblesAndUser } from "../managers/CollectibleManager"
-import { AspectRatio, Card, Container, Grid, Inset } from "@radix-ui/themes";
-
 
 
 export const CategoryFilter = ({ categories, selectedCategory, setSelectedCategory }) => {

--- a/src/components/collectibles/CollectiblesPage.jsx
+++ b/src/components/collectibles/CollectiblesPage.jsx
@@ -1,46 +1,21 @@
 import { useEffect, useState } from "react";
 import { getAllCollectiblesAndUser } from "../managers/CollectibleManager";
-import { getAllCategories } from "../managers/CategoriesManager";
-import { CategoryFilter } from "./CategoryFilter";
 import { CollectiblesList } from "./CollectiblesList";
 
-
-
-export const CollectiblesPage = () => {
+export const CollectiblesPage = ({ categories, selectedCategory }) => {
   const [collectibles, setCollectibles] = useState([]);
-  const [categories, setCategories] = useState([]);
-  const [selectedCategory, setSelectedCategory] = useState('all');
-  const [filteredCollectibles, setFilteredItems] = useState([]);
-
+  const [filteredCollectibles, setFilteredCollectibles] = useState([]);
 
   useEffect(() => {
     getAllCollectiblesAndUser().then(setCollectibles);
-    getAllCategories().then(setCategories);
   }, []);
 
   useEffect(() => {
-    if (selectedCategory === 'all') {
-      setFilteredItems(collectibles);
-    } else {
-      // Parse selectedCategory as an integer
-      const selectedCategoryId = parseInt(selectedCategory);
-      // Filter collectibles where the categories array includes the selectedCategoryId
-      const filtered = collectibles.filter(collectible => 
-        collectible.categories.includes(selectedCategoryId)
-      );
-  
-      setFilteredItems(filtered);
-    }
+    const filtered = selectedCategory === 'all' 
+      ? collectibles 
+      : collectibles.filter(collectible => collectible.categories.includes(parseInt(selectedCategory)));
+    setFilteredCollectibles(filtered);
   }, [selectedCategory, collectibles]);
 
-  return (
-    <>
-      <CategoryFilter
-        categories={categories} 
-        setSelectedCategory={setSelectedCategory} 
-        selectedCategory={selectedCategory} 
-      />
-      <CollectiblesList collectibles={filteredCollectibles} />
-    </>
-  );
+  return <CollectiblesList collectibles={filteredCollectibles} />;
 };

--- a/src/components/collectibles/SearchBar.jsx
+++ b/src/components/collectibles/SearchBar.jsx
@@ -1,0 +1,15 @@
+
+
+
+
+export const SearchBar = ({ onSearchChange }) => {
+    return (
+      <input 
+        type="text" 
+        placeholder="Search collectibles..." 
+        onChange={(e) => onSearchChange(e.target.value)}
+        className="search-input-class" // Add your CSS class for styling
+      />
+    );
+  };
+  

--- a/src/components/navbar/navbar.jsx
+++ b/src/components/navbar/navbar.jsx
@@ -4,10 +4,10 @@ import { useEffect, useState } from "react";
 import { getPixoUserById } from "../managers/PixoUserManager";
 import { getAllCategories } from "../managers/CategoriesManager";
 import { ProfileDropDown } from "./ProfileDropDown";
+import { CategoryFilter } from "../collectibles/CategoryFilter";
 
 export const NavBar = ( {userId, setToken, categories, selectedCategory, setSelectedCategory }) => {
   const [pixoUser, setPixoUser] = useState([])
-  const navigate = useNavigate();
 
 
   useEffect(() => {
@@ -25,6 +25,8 @@ export const NavBar = ( {userId, setToken, categories, selectedCategory, setSele
               <span className="ml-2 text-2xl font-bold">Pixo</span>
             </NavLink>
           </div>
+          <CategoryFilter className=""
+          categories={categories} selectedCategory={selectedCategory} setSelectedCategory={setSelectedCategory} />
           <div className="m-5 flex-shrink-0 flex items-center">
             <ProfileDropDown userId={userId} pixoUser={pixoUser} setToken={setToken}/>
           </div>

--- a/src/views/ApplicationViews.jsx
+++ b/src/views/ApplicationViews.jsx
@@ -1,27 +1,45 @@
-import { Route, Routes } from "react-router-dom";
-import { Login } from "../components/auth/Login";
-import { Register } from "../components/auth/Register";
-import { Authorized } from "./Authorized";
-import { CollectibleDetails } from "../components/collectibles/CollectibleDetails";
-import { ProfileView } from "../components/profile/ProfileView";
-import { CreateCollectibleForm } from "../components/collectibles/CreateCollectibleForm";
-import { EditCollectibleForm } from "../components/collectibles/EditCollectibleForm";
-import { CollectiblesPage } from "../components/collectibles/CollectiblesPage";
+import { useState, useEffect } from 'react';
+import { Route, Routes, Navigate } from 'react-router-dom';
+import { Login } from '../components/auth/Login';
+import { Register } from '../components/auth/Register';
+import { CollectibleDetails } from '../components/collectibles/CollectibleDetails';
+import { ProfileView } from '../components/profile/ProfileView';
+import { CreateCollectibleForm } from '../components/collectibles/CreateCollectibleForm';
+import { EditCollectibleForm } from '../components/collectibles/EditCollectibleForm';
+import { CollectiblesPage } from '../components/collectibles/CollectiblesPage';
+import { NavBar } from '../components/navbar/navbar';
+import { getAllCategories } from '../components/managers/CategoriesManager';
 
 export const ApplicationViews = ({ token, setToken, userId, setCurrentUserId }) => {
+  const [categories, setCategories] = useState([]);
+  const [selectedCategory, setSelectedCategory] = useState('all');
 
-    
+
+
+  useEffect(() => {
+    getAllCategories().then(setCategories);
+  }, []);
+
+  const isAuthenticated = () => localStorage.getItem("auth_token");
+
   return (
-    <Routes>
-      <Route path="/login" element={<Login setToken={setToken} setCurrentUserId={setCurrentUserId} />} />
-      <Route path="/register" element={<Register setToken={setToken} setCurrentUserId={setCurrentUserId} />} />
-      <Route path="/" element={<Authorized token={token} setToken={setToken} userId={userId} />}>
-        <Route index element={<CollectiblesPage /> } />
-        <Route path="/item/:itemId" element={<CollectibleDetails /> } />
-        <Route path="/profile" element={<ProfileView userId={userId}/> } />
-        <Route path="/create" element={<CreateCollectibleForm /> } />
-        <Route path="/edit/:itemId" element={<EditCollectibleForm userId={userId} /> } />
-      </Route>
-    </Routes>
+    <div>
+      {isAuthenticated() && <NavBar  userId={userId} setToken={setToken} categories={categories} selectedCategory={selectedCategory} setSelectedCategory={setSelectedCategory} />}
+      <Routes>
+        <Route path="/login" element={<Login setToken={setToken} setCurrentUserId={setCurrentUserId} />} />
+        <Route path="/register" element={<Register setToken={setToken} setCurrentUserId={setCurrentUserId} />} />
+        {isAuthenticated() ? (
+          <>
+            <Route path="/" element={<CollectiblesPage categories={categories} selectedCategory={selectedCategory} />} />
+            <Route path="/item/:itemId" element={<CollectibleDetails />} />
+            <Route path="/profile" element={<ProfileView userId={userId} />} />
+            <Route path="/create" element={<CreateCollectibleForm />} />
+            <Route path="/edit/:itemId" element={<EditCollectibleForm userId={userId} />} />
+          </>
+        ) : (
+          <Route path="*" element={<Navigate to="/login" replace />} />
+        )}
+      </Routes>
+    </div>
   );
 };


### PR DESCRIPTION
### Description

This PR focuses on enhancing the application's UI/UX by integrating the category filter directly into the NavBar. Previously, the category filtering functionality was a separate component within the Collectibles page. The refactor improves the application's overall layout and design consistency.

### Changes 

- **NavBar Update**: Incorporated CategoryFilter into the NavBar component, allowing users to filter collectibles from any page.
- **State Lifting**: Moved the state management for categories and selected categories up to the ```ApplicationViews``` component to maintain a consistent state across the application.
-**Refactor CollectiblesPage:** Simplified CollectiblesPage to focus solely on displaying the list of collectibles, as the filtering logic has been moved to the NavBar. 
- **Prop Drilling:** Passed necessary state and handlers (categories, selectedCategory, setSelectedCategory) as props from ApplicationViews to NavBar and other child components.
- **Clean-Up:** Removed redundant code and state from components where the category filter was previously implemented.

## How To Test
- Navigate to various pages within the application and observe the consistent presence of the category filter in the NavBar.
- Use the category filter to select different categories and verify that the collectibles list on the main page updates accordingly.
- Ensure that the state remains consistent when navigating between pages after applying category filters.
