### PR TITLE
Refactor: Categories back to Collectibles Page 

### DIFF
--- a/src/components/collectibles/CategoryFilter.jsx
+++ b/src/components/collectibles/CategoryFilter.jsx
@@ -8,8 +8,9 @@ import { AspectRatio, Card, Container, Grid, Inset } from "@radix-ui/themes";
 export const CategoryFilter = ({ categories, selectedCategory, setSelectedCategory }) => {
 
 
-    return (<><div>
-          <div>
+    return (<>
+      <div>
+        <div className="flex justify-start ml-auto mr-auto p-4 max-w-screen-lg mb-5">
           <select
             className="category-filter"
             value={selectedCategory} 


### PR DESCRIPTION
### Description 

This PR reverts a previous change that placed the category filter in the NavBar, moving it back to the Collectibles page. After further consideration and feedback, it was determined that having the category filter directly on the Collectibles page provides a more intuitive and streamlined user experience, particularly as the filter is specifically relevant to the collectibles being displayed. When the category filter was on the homepage, it did not make sense when the user navigated to items detail page or profile for the filter bar to still appear. This helps with the user experience. 

## Changes Made:
- Remove Category Filter from NavBar: The CategoryFilter component has been removed from the NavBar to simplify the navigation bar and keep it focused on global navigation functions.
- Integrate Category Filter into Collectibles Page: The CategoryFilter is now reintegrated into the CollectiblesPage, aligning it closely with the collectibles list for a more cohesive user experience.
- State Management Adjustments: Adjusted state management in ApplicationViews and CollectiblesPage to handle category selection within the context of the collectibles list.
- UI and Layout Updates: Updated the layout and styling of the CollectiblesPage to accommodate the CategoryFilter in a visually appealing and user-friendly manner.

## How to Test:
- Navigate to the Collectibles page.
- Use the category filter to select different categories.
- Observe that the collectibles list updates according to the selected category.
- Ensure that the filter's functionality and appearance are consistent and intuitive.